### PR TITLE
Remove load dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/settings.js
+++ b/src/settings.js
@@ -10,5 +10,6 @@ module.exports = {
 	height: 200,
 	TIMELINE_SCROLL_HEIGHT: 0,
 	LEFT_PANE_WIDTH: 250,
-	time_scale: DEFAULT_TIME_SCALE // number of pixels to 1 secon,
+	time_scale: DEFAULT_TIME_SCALE, // number of pixels to 1 second
+    default_length: 20, // seconds
 };

--- a/src/timeliner.js
+++ b/src/timeliner.js
@@ -333,9 +333,9 @@ function Timeliner(target) {
 		if (data.getValue('ui') === undefined) {
 			data.setValue('ui', {
 				currentTime: 0,
-				totalTime: 20,
+				totalTime: Settings.default_length,
 				scrollTime: 0,
-				timeScale: 40
+				timeScale: Settings.time_scale
 			});
 		}
 

--- a/src/util_datastore.js
+++ b/src/util_datastore.js
@@ -1,5 +1,6 @@
 var package_json = require('../package.json'),
-Do = require('do.js');
+	Settings = require('./settings'),
+	Do = require('do.js');
 
 // Data Store with a source of truth
 function DataStore() {
@@ -24,6 +25,13 @@ DataStore.prototype.blank = function() {
 	data.version = package_json.version;
 	data.modified = new Date().toString();
 	data.title = 'Untitled';
+
+	data.ui = {
+		currentTime: 0,
+		totalTime: Settings.default_length,
+		scrollTime: 0,
+		timeScale: Settings.time_scale
+	};
 
 	data.layers = [];
 


### PR DESCRIPTION
The current release requires a timeliner.load() call to be made before the timeline can be used. This update creates a default set of ui params in the DataStore.blank() function, allowing the first example in test.html to work again.

That is, this change re-enables the following paradigm:

````js
var timeliner = new Timeliner(target);
timeliner.addLayer('x');
timeliner.addLayer('y');
timeliner.addLayer('rotate');
````